### PR TITLE
Add Gaussian scale initialization via projective depth estimation

### DIFF
--- a/arguments/__init__.py
+++ b/arguments/__init__.py
@@ -55,6 +55,7 @@ class ModelParams(ParamGroup):
         self.data_device = "cuda"
         self.eval = False
         self.n_views = 0
+        self.init_scale_from_view_depth = False
         super().__init__(parser, "Loading Parameters", sentinel)
 
     def extract(self, args):


### PR DESCRIPTION
Initialize each Gaussian’s scale via projective geometry, using the point’s depth (from its closest view) divided by the average focal length, rather than relying on pairwise distances.