### PR TITLE
fix: MST init omits pairwise scale in camera poses

### DIFF
--- a/dust3r/cloud_opt/init_im_poses.py
+++ b/dust3r/cloud_opt/init_im_poses.py
@@ -179,7 +179,7 @@ def minimum_spanning_tree(imshapes, edges, pred_i, pred_j, conf_i, conf_j, im_co
             msp_edges.append((i, j))
 
             if has_im_poses and im_poses[i] is None:
-                im_poses[i] = sRT_to_4x4(1, R, T, device)
+                im_poses[i] = sRT_to_4x4(s, R, T, device)
 
         elif j in done:
             if verbose:


### PR DESCRIPTION
### Problem
fix: MST init omits pairwise scale in camera poses

### Fix
Replace:
```
            if has_im_poses and im_poses[i] is None:
                im_poses[i] = sRT_to_4x4(1, R, T, device)
```

with:
```
            if has_im_poses and im_poses[i] is None:
                im_poses[i] = sRT_to_4x4(s, R, T, device)
```

### Files changed
- `dust3r/cloud_opt/init_im_poses.py`