### PR TITLE
fix: SceneViz.add_rgbd does not convert image paths to arrays

### DIFF
--- a/dust3r/viz.py
+++ b/dust3r/viz.py
@@ -171,6 +171,7 @@ class SceneViz:
         return self
 
     def add_rgbd(self, image, depth, intrinsics=None, cam2world=None, zfar=np.inf, mask=None):
+        image = img_to_arr(image)
         # make up some intrinsics
         if intrinsics is None:
             H, W, THREE = image.shape


### PR DESCRIPTION
### Problem
fix: SceneViz.add_rgbd does not convert image paths to arrays

### Fix
Replace:
```
    def add_rgbd(self, image, depth, intrinsics=None, cam2world=None, zfar=np.inf, mask=None):
        # make up some intrinsics
        if intrinsics is None:
            H, W, THREE = image.shape
```

with:
```
    def add_rgbd(self, image, depth, intrinsics=None, cam2world=None, zfar=np.inf, mask=None):
        image = img_to_arr(image)
        # make up some intrinsics
        if intrinsics is None:
            H, W, THREE = image.shape
```

### Files changed
- `dust3r/viz.py`