### PR TITLE
fix: test dataset log message prints train_dataset

### DIFF
--- a/dust3r/training.py
+++ b/dust3r/training.py
@@ -119,7 +119,7 @@ def train(args):
     print('Building train dataset {:s}'.format(args.train_dataset))
     #  dataset and loader
     data_loader_train = build_dataset(args.train_dataset, args.batch_size, args.num_workers, test=False)
-    print('Building test dataset {:s}'.format(args.train_dataset))
+    print('Building test dataset {:s}'.format(args.test_dataset))
     data_loader_test = {dataset.split('(')[0]: build_dataset(dataset, args.batch_size, args.num_workers, test=True)
                         for dataset in args.test_dataset.split('+')}
 


### PR DESCRIPTION
### Problem
fix: test dataset log message prints train_dataset

### Fix
Replace:
```
    print('Building test dataset {:s}'.format(args.train_dataset))
```

with:
```
    print('Building test dataset {:s}'.format(args.test_dataset))
```

### Files changed
- `dust3r/training.py`