### PR TITLE
fix: ConfLoss returns Python int 0 for empty valid masks

### DIFF
--- a/dust3r/losses.py
+++ b/dust3r/losses.py
@@ -232,8 +232,8 @@ class ConfLoss (MultiLoss):
         conf_loss2 = loss2 * conf2 - self.alpha * log_conf2
 
         # average + nan protection (in case of no valid pixels at all)
-        conf_loss1 = conf_loss1.mean() if conf_loss1.numel() > 0 else 0
-        conf_loss2 = conf_loss2.mean() if conf_loss2.numel() > 0 else 0
+        conf_loss1 = conf_loss1.mean() if conf_loss1.numel() > 0 else conf_loss1.new_zeros(())
+        conf_loss2 = conf_loss2.mean() if conf_loss2.numel() > 0 else conf_loss2.new_zeros(())
 
         return conf_loss1 + conf_loss2, dict(conf_loss_1=float(conf_loss1), conf_loss2=float(conf_loss2), **details)
 


### PR DESCRIPTION
### Problem
fix: ConfLoss returns Python int 0 for empty valid masks

### Fix
Replace:
```
        conf_loss1 = conf_loss1.mean() if conf_loss1.numel() > 0 else 0
        conf_loss2 = conf_loss2.mean() if conf_loss2.numel() > 0 else 0
```

with:
```
        conf_loss1 = conf_loss1.mean() if conf_loss1.numel() > 0 else conf_loss1.new_zeros(())
        conf_loss2 = conf_loss2.mean() if conf_loss2.numel() > 0 else conf_loss2.new_zeros(())
```

### Files changed
- `dust3r/losses.py`