### PR TITLE
fix: use uint8 instead of signed byte for image array

### DIFF
--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -400,7 +400,7 @@ def readCamerasFromTransforms(path, transformsfile, white_background, extension=
 
             norm_data = im_data / 255.0
             arr = norm_data[:,:,:3] * norm_data[:, :, 3:4] + bg * (1 - norm_data[:, :, 3:4])
-            image = Image.fromarray(np.array(arr*255.0, dtype=np.byte), "RGB")
+            image = Image.fromarray(np.array(arr*255.0, dtype=np.uint8), "RGB")
 
             fovy = focal2fov(fov2focal(fovx, image.size[0]), image.size[1])
             FovY = fovy 


### PR DESCRIPTION
### Problem
fix: use uint8 instead of signed byte for image array

### Fix
Replace:
```
            image = Image.fromarray(np.array(arr*255.0, dtype=np.byte), "RGB")
```

with:
```
            image = Image.fromarray(np.array(arr*255.0, dtype=np.uint8), "RGB")
```

### Files changed
- `scene/dataset_readers.py`