### PR TITLE
fix: avoid double path join when loading NeRF images

### DIFF
--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -378,7 +378,7 @@ def readCamerasFromTransforms(path, transformsfile, white_background, extension=
 
         frames = contents["frames"]
         for idx, frame in enumerate(frames):
-            cam_name = os.path.join(path, frame["file_path"] + extension)
+            cam_name = frame["file_path"] + extension
 
             # NeRF 'transform_matrix' is a camera-to-world transform
             c2w = np.array(frame["transform_matrix"])


### PR DESCRIPTION
### Problem
fix: avoid double path join when loading NeRF images

### Fix
Replace:
```
            cam_name = os.path.join(path, frame["file_path"] + extension)
```

with:
```
            cam_name = frame["file_path"] + extension
```

### Files changed
- `scene/dataset_readers.py`