### PR TITLE
fix: supply train_poses and test_poses to SceneInfo

### DIFF
--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -444,7 +444,9 @@ def readNerfSyntheticInfo(path, white_background, eval, extension=".png"):
                            train_cameras=train_cam_infos,
                            test_cameras=test_cam_infos,
                            nerf_normalization=nerf_normalization,
-                           ply_path=ply_path)
+                           ply_path=ply_path,
+                           train_poses=[],
+                           test_poses=[])
     return scene_info
 
 sceneLoadTypeCallbacks = {


### PR DESCRIPTION
### Problem
fix: supply train_poses and test_poses to SceneInfo

### Fix
Replace:
```
    scene_info = SceneInfo(point_cloud=pcd,
                           train_cameras=train_cam_infos,
                           test_cameras=test_cam_infos,
                           nerf_normalization=nerf_normalization,
                           ply_path=ply_path)
    return scene_info
```

with:
```
    scene_info = SceneInfo(point_cloud=pcd,
                           train_cameras=train_cam_infos,
                           test_cameras=test_cam_infos,
                           nerf_normalization=nerf_normalization,
                           ply_path=ply_path,
                           train_poses=[],
                           test_poses=[])
    return scene_info
```

### Files changed
- `scene/dataset_readers.py`