### PR TITLE
fix: add missing cv2 import for SIMPLE_RADIAL undistortion

### DIFF
--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -13,6 +13,7 @@ import os
 import sys
 import torch
 from PIL import Image
+import cv2
 from typing import NamedTuple
 from scene.colmap_loader import read_extrinsics_text, read_intrinsics_text, qvec2rotmat, \
     read_extrinsics_binary, read_intrinsics_binary, read_points3D_binary, read_points3D_text


### PR DESCRIPTION
### Problem
fix: add missing cv2 import for SIMPLE_RADIAL undistortion

### Fix
Replace:
```
from PIL import Image
from typing import NamedTuple
```

with:
```
from PIL import Image
import cv2
from typing import NamedTuple
```

### Files changed
- `scene/dataset_readers.py`