### PR TITLE
fix: gamma==1 ignores mul and clip parameters

### DIFF
--- a/mast3r/cloud_opt/utils/losses.py
+++ b/mast3r/cloud_opt/utils/losses.py
@@ -19,7 +19,9 @@ def l1_loss(x, y):
 def gamma_loss(gamma, mul=1, offset=None, clip=np.inf):
     if offset is None:
         if gamma == 1:
-            return l1_loss
+            def loss_func(x, y):
+                return mul * l1_loss(x, y).clip(max=clip)
+            return loss_func
         # d(x**p)/dx = 1 ==> p * x**(p-1) == 1 ==> x = (1/p)**(1/(p-1))
         offset = (1 / gamma)**(1 / (gamma - 1))
 


### PR DESCRIPTION
### Problem
fix: gamma==1 ignores mul and clip parameters

### Fix
Replace:
```
    if offset is None:
        if gamma == 1:
            return l1_loss
        # d(x**p)/dx = 1 ==> p * x**(p-1) == 1 ==> x = (1/p)**(1/(p-1))
        offset = (1 / gamma)**(1 / (gamma - 1))
```

with:
```
    if offset is None:
        if gamma == 1:
            def loss_func(x, y):
                return mul * l1_loss(x, y).clip(max=clip)
            return loss_func
        # d(x**p)/dx = 1 ==> p * x**(p-1) == 1 ==> x = (1/p)**(1/(p-1))
        offset = (1 / gamma)**(1 / (gamma - 1))
```

### Files changed
- `mast3r/cloud_opt/utils/losses.py`