### PR TITLE
fix: conf.cuda() causes CPU/CUDA device mismatch

### DIFF
--- a/mast3r/cloud_opt/tsdf_optimizer.py
+++ b/mast3r/cloud_opt/tsdf_optimizer.py
@@ -123,7 +123,7 @@ class TSDFPostProcess:
                                            H) & torch.logical_and(0 <= imc[:, 0], imc[:, 0] < W)
             imc[~valids[ni]] = 0
             depths[ni] = depth[imc[:, 1], imc[:, 0]]
-            confs[ni] = conf.cuda()[imc[:, 1], imc[:, 0]]
+            confs[ni] = conf.to(imc.device)[imc[:, 1], imc[:, 0]]
         return depths, confs, valids
 
     def _get_confs_with_normals(self):


### PR DESCRIPTION
### Problem
fix: conf.cuda() causes CPU/CUDA device mismatch

### Fix
Replace:
```
            depths[ni] = depth[imc[:, 1], imc[:, 0]]
            confs[ni] = conf.cuda()[imc[:, 1], imc[:, 0]]
        return depths, confs, valids
```

with:
```
            depths[ni] = depth[imc[:, 1], imc[:, 0]]
            confs[ni] = conf.to(imc.device)[imc[:, 1], imc[:, 0]]
        return depths, confs, valids
```

### Files changed
- `mast3r/cloud_opt/tsdf_optimizer.py`