### PR TITLE
fix: wrong first argument passed to _refine_depths_with_TSDF

### DIFF
--- a/mast3r/cloud_opt/tsdf_optimizer.py
+++ b/mast3r/cloud_opt/tsdf_optimizer.py
@@ -26,7 +26,7 @@ class TSDFPostProcess:
 
     def _get_depthmaps(self, TSDF_filtering_thresh=None):
         if TSDF_filtering_thresh:
-            self._refine_depths_with_TSDF(self.optimizer, TSDF_filtering_thresh)  # compute refined depths if needed
+            self._refine_depths_with_TSDF(TSDF_filtering_thresh)  # compute refined depths if needed
         dms = self.TSDF_im_depthmaps if TSDF_filtering_thresh else self.im_depthmaps
         return [d.exp() for d in dms]
 


### PR DESCRIPTION
### Problem
fix: wrong first argument passed to _refine_depths_with_TSDF

### Fix
Replace:
```
    def _get_depthmaps(self, TSDF_filtering_thresh=None):
        if TSDF_filtering_thresh:
            self._refine_depths_with_TSDF(self.optimizer, TSDF_filtering_thresh)  # compute refined depths if needed
        dms = self.TSDF_im_depthmaps if TSDF_filtering_thresh else self.im_depthmaps
        return [d.exp() for d in dms]
```

with:
```
    def _get_depthmaps(self, TSDF_filtering_thresh=None):
        if TSDF_filtering_thresh:
            self._refine_depths_with_TSDF(TSDF_filtering_thresh)  # compute refined depths if needed
        dms = self.TSDF_im_depthmaps if TSDF_filtering_thresh else self.im_depthmaps
        return [d.exp() for d in dms]
```

### Files changed
- `mast3r/cloud_opt/tsdf_optimizer.py`